### PR TITLE
Handle missing Linux sandbox gracefully

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -18,3 +18,14 @@
 
 *(New entries go on top. Keep each under ~20 lines.)*
 
+### [2025-08-17] missing-sandbox-error
+- **Context:** `codex-cli` panicked when the `codex-linux-sandbox` binary was missing.
+- **Decision:** Return a descriptive error instead of panicking so users understand the failure.
+- **Alternatives:** Keep using `.expect` and crash.
+- **Trade-offs:** Slightly more code; reliance on error handling.
+- **Scope:** `codex-rs/cli` sandbox command path.
+- **Impact:** CLI fails gracefully when Landlock sandbox is requested without the binary.
+- **TTL / Review:** Revisit if sandbox architecture changes.
+- **Status:** ACTIVE
+- **Links:** See PR for missing sandbox executable handling.
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -37,3 +37,14 @@
 
 *(Append new capabilities below using the format above. Keep the list curated; collapse removed items to a brief tombstone if noisy.)*
 
+### Capability: graceful-missing-sandbox
+- **Purpose:** Ensure the CLI reports a clear error when the `codex-linux-sandbox` binary is absent.
+- **Scope:** `codex-rs/cli` Landlock sandbox execution path.
+- **Shape:** Attempting Landlock without the binary yields a descriptive failure instead of a panic.
+- **Compatibility:** No flags or migrations; failure surfaces as an error.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `codex-rs/cli/src/debug_sandbox.rs::missing_linux_sandbox_binary_returns_error`
+- **Linked Decisions:** [2025-08-17] missing-sandbox-error
+- **Notes:** n/a
+

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "codex-mcp-server",
  "codex-tui",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -36,3 +36,6 @@ tokio = { version = "1", features = [
 ] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
### WHY
- avoid panic when `codex-linux-sandbox` is missing so users see a clear error

### OUTCOME
- Landlock execution returns a descriptive error if the sandbox binary isn't present and a test covers this case

### SURFACES TOUCHED
- `codex-rs/cli/src/debug_sandbox.rs`
- `codex-rs/cli/Cargo.toml`
- `GOALS.md`
- `DECISIONS.md`

### EXIT VIA SCENES
- `cargo test -p codex-cli`

### COMPATIBILITY
- no migrations or flags; failure surfaces as an error

### NO-GO
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68a259a1f50c832c9177a672de7f7c1f