### PR TITLE
test: add cli integration tests

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -656,6 +656,7 @@ name = "codex-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clap_complete",
  "codex-arg0",
@@ -666,6 +667,7 @@ dependencies = [
  "codex-login",
  "codex-mcp-server",
  "codex-tui",
+ "predicates",
  "serde_json",
  "tempfile",
  "tokio",

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -39,3 +39,5 @@ tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
 tempfile = "3"
+assert_cmd = "2"
+predicates = "3"

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -7,9 +7,11 @@ use codex_chatgpt::apply_command::ApplyCommand;
 use codex_chatgpt::apply_command::run_apply_command;
 use codex_cli::LandlockCommand;
 use codex_cli::SeatbeltCommand;
-use codex_cli::login::{
-    LoginStatus, run_login_status, run_login_with_api_key, run_login_with_chatgpt, run_logout,
-};
+use codex_cli::login::LoginStatus;
+use codex_cli::login::run_login_status;
+use codex_cli::login::run_login_with_api_key;
+use codex_cli::login::run_login_with_chatgpt;
+use codex_cli::login::run_logout;
 use codex_cli::proto;
 use codex_common::CliConfigOverrides;
 use codex_exec::Cli as ExecCli;
@@ -228,4 +230,26 @@ fn print_completion(cmd: CompletionCommand) {
     let mut app = MultitoolCli::command();
     let name = "codex";
     generate(cmd.shell, &mut app, name, &mut std::io::stdout());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_flags_are_prepended() {
+        let mut sub = CliConfigOverrides {
+            raw_overrides: vec!["a=1".into()],
+        };
+        let root = CliConfigOverrides {
+            raw_overrides: vec!["a=2".into()],
+        };
+
+        prepend_config_flags(&mut sub, root);
+
+        assert_eq!(
+            sub.raw_overrides,
+            vec![String::from("a=2"), String::from("a=1")]
+        );
+    }
 }

--- a/codex-rs/cli/tests/login_status.rs
+++ b/codex-rs/cli/tests/login_status.rs
@@ -1,0 +1,16 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::tempdir;
+
+#[test]
+fn login_status_not_logged_in() {
+    let dir = tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("codex").unwrap();
+    cmd.env("CODEX_HOME", dir.path())
+        .env_remove("OPENAI_API_KEY")
+        .arg("login")
+        .arg("status")
+        .assert()
+        .failure()
+        .stderr(contains("Not logged in"));
+}

--- a/codex-rs/cli/tests/proto.rs
+++ b/codex-rs/cli/tests/proto.rs
@@ -1,0 +1,12 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn proto_help_runs() {
+    Command::cargo_bin("codex")
+        .unwrap()
+        .args(["proto", "--help"])
+        .assert()
+        .success()
+        .stdout(contains("Protocol"));
+}

--- a/codex-rs/cli/tests/sandbox_mode.rs
+++ b/codex-rs/cli/tests/sandbox_mode.rs
@@ -1,0 +1,12 @@
+use codex_cli::debug_sandbox::create_sandbox_mode;
+use codex_core::config_types::SandboxMode;
+
+#[test]
+fn full_auto_enables_workspace_write() {
+    assert_eq!(create_sandbox_mode(true), SandboxMode::WorkspaceWrite);
+}
+
+#[test]
+fn default_is_read_only() {
+    assert_eq!(create_sandbox_mode(false), SandboxMode::ReadOnly);
+}


### PR DESCRIPTION
## WHY
- ensure codex cli subcommands are covered by integration tests

## OUTCOME
- exercise `login status` and `proto` subcommands via `assert_cmd`
- verify `create_sandbox_mode` and config flag precedence behavior

## SURFACES TOUCHED
- `codex-rs/cli`

## EXIT VIA SCENES
- `cargo test -p codex-cli`

## COMPATIBILITY
- no breaking changes expected

## NO-GO
- failing `cargo test -p codex-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a273f6b1e4832ca8b4b6d9eddc505a