### PR TITLE
chore(cli): deduplicate PATH updates

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6,6 +6,7 @@
 ## Entry Template
 
 ### [YYYY-MM-DD] <short handle>
+
 - **Context:** <why a choice was necessary; constraints at play>
 - **Decision:** <the chosen path in one or two sentences>
 - **Alternatives:** <bulleted, only those genuinely considered>
@@ -16,9 +17,22 @@
 - **Status:** ACTIVE | REPLACED | REJECTED | BLOCKED
 - **Links:** <PRs, scenes, interface entries, goal names>
 
-*(New entries go on top. Keep each under ~20 lines.)*
+_(New entries go on top. Keep each under ~20 lines.)_
+
+### [2025-08-29] cli-path-dedup
+
+- **Context:** Repeated CLI launches added duplicate directories to `PATH` causing unbounded growth.
+- **Decision:** Skip directories already present in `PATH` when computing the updated value.
+- **Alternatives:** Keep existing behavior and allow duplicates.
+- **Trade-offs:** Slight increase in startup logic complexity.
+- **Scope:** `codex-cli/bin/codex.js`.
+- **Impact:** CLI startup is idempotent with respect to environment `PATH`.
+- **TTL / Review:** Revisit if environment handling changes.
+- **Status:** ACTIVE
+- **Links:** goal cli-path-deduplication; `codex-cli/test/path.test.js`
 
 ### [2025-08-17] missing-sandbox-error
+
 - **Context:** `codex-cli` panicked when the `codex-linux-sandbox` binary was missing.
 - **Decision:** Return a descriptive error instead of panicking so users understand the failure.
 - **Alternatives:** Keep using `.expect` and crash.
@@ -30,6 +44,7 @@
 - **Links:** See PR for missing sandbox executable handling.
 
 ### [2025-08-19] login-result-handling
+
 - **Context:** Login helpers exited the process directly, making reuse and testing difficult.
 - **Decision:** Return `Result`/status enums from login helpers and manage exits in `main.rs`.
 - **Alternatives:** Keep process termination inside helper functions.
@@ -39,4 +54,3 @@
 - **TTL / Review:** Revisit when authentication flow changes.
 - **Status:** ACTIVE
 - **Links:** goal result-based-login
-

--- a/GOALS.md
+++ b/GOALS.md
@@ -14,6 +14,7 @@
 ## Capability Entry Format (copy/paste)
 
 ### Capability: <short name>
+
 - **Purpose:** <why this exists in the product; 1–2 lines>
 - **Scope:** <surfaces affected (modules/apis/clis/data)>
 - **Shape:** <behavioural invariants asserted by scenes; no numbers>
@@ -35,9 +36,10 @@
 
 ## Current Capabilities
 
-*(Append new capabilities below using the format above. Keep the list curated; collapse removed items to a brief tombstone if noisy.)*
+_(Append new capabilities below using the format above. Keep the list curated; collapse removed items to a brief tombstone if noisy.)_
 
 ### Capability: graceful-missing-sandbox
+
 - **Purpose:** Ensure the CLI reports a clear error when the `codex-linux-sandbox` binary is absent.
 - **Scope:** `codex-rs/cli` Landlock sandbox execution path.
 - **Shape:** Attempting Landlock without the binary yields a descriptive failure instead of a panic.
@@ -49,6 +51,7 @@
 - **Notes:** n/a
 
 ### Capability: result-based-login
+
 - **Purpose:** Allow CLI login helpers to return structured results for better control and testing.
 - **Scope:** `codex-rs/cli` login module and main entrypoint.
 - **Shape:** login operations yield `Result`/status enums; caller decides process exit.
@@ -59,3 +62,14 @@
 - **Linked Decisions:** [2025-08-19] login-result-handling
 - **Notes:** n/a
 
+### Capability: cli-path-deduplication
+
+- **Purpose:** Prevent the Codex CLI from duplicating directories when updating `PATH`.
+- **Scope:** `codex-cli` startup environment handling.
+- **Shape:** Repeated CLI invocations do not accumulate duplicate `PATH` segments.
+- **Compatibility:** no flags; existing environment variables remain unchanged.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `codex-cli/test/path.test.js`
+- **Linked Decisions:** [2025-08-29] cli-path-dedup
+- **Notes:** n/a

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -2,68 +2,11 @@
 // Unified entry point for the Codex CLI.
 
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 // __dirname equivalent in ESM
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-const { platform, arch } = process;
-
-let targetTriple = null;
-switch (platform) {
-  case "linux":
-  case "android":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-unknown-linux-musl";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-unknown-linux-musl";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "darwin":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-apple-darwin";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-apple-darwin";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "win32":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-pc-windows-msvc.exe";
-        break;
-      case "arm64":
-      // We do not build this today, fall through...
-      default:
-        break;
-    }
-    break;
-  default:
-    break;
-}
-
-if (!targetTriple) {
-  throw new Error(`Unsupported platform: ${platform} (${arch})`);
-}
-
-const binaryPath = path.join(__dirname, "..", "bin", `codex-${targetTriple}`);
-
-// Use an asynchronous spawn instead of spawnSync so that Node is able to
-// respond to signals (e.g. Ctrl-C / SIGINT) while the native binary is
-// executing. This allows us to forward those signals to the child process
-// and guarantees that when either the child terminates or the parent
-// receives a fatal signal, both processes exit in a predictable manner.
-const { spawn } = await import("child_process");
 
 async function tryImport(moduleName) {
   try {
@@ -82,75 +25,136 @@ async function resolveRgDir() {
   return path.dirname(ripgrep.rgPath);
 }
 
-function getUpdatedPath(newDirs) {
+export function getUpdatedPath(newDirs) {
   const pathSep = process.platform === "win32" ? ";" : ":";
   const existingPath = process.env.PATH || "";
-  const updatedPath = [
-    ...newDirs,
-    ...existingPath.split(pathSep).filter(Boolean),
-  ].join(pathSep);
-  return updatedPath;
+  const existingDirs = existingPath.split(pathSep).filter(Boolean);
+  const filteredDirs = newDirs.filter((dir) => !existingDirs.includes(dir));
+  return [...filteredDirs, ...existingDirs].join(pathSep);
 }
 
-const additionalDirs = [];
-const rgDir = await resolveRgDir();
-if (rgDir) {
-  additionalDirs.push(rgDir);
-}
-const updatedPath = getUpdatedPath(additionalDirs);
+async function main() {
+  const { platform, arch } = process;
 
-const child = spawn(binaryPath, process.argv.slice(2), {
-  stdio: "inherit",
-  env: { ...process.env, PATH: updatedPath, CODEX_MANAGED_BY_NPM: "1" },
-});
-
-child.on("error", (err) => {
-  // Typically triggered when the binary is missing or not executable.
-  // Re-throwing here will terminate the parent with a non-zero exit code
-  // while still printing a helpful stack trace.
-  // eslint-disable-next-line no-console
-  console.error(err);
-  process.exit(1);
-});
-
-// Forward common termination signals to the child so that it shuts down
-// gracefully. In the handler we temporarily disable the default behavior of
-// exiting immediately; once the child has been signaled we simply wait for
-// its exit event which will in turn terminate the parent (see below).
-const forwardSignal = (signal) => {
-  if (child.killed) {
-    return;
+  let targetTriple = null;
+  switch (platform) {
+    case "linux":
+    case "android":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-unknown-linux-musl";
+          break;
+        case "arm64":
+          targetTriple = "aarch64-unknown-linux-musl";
+          break;
+        default:
+          break;
+      }
+      break;
+    case "darwin":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-apple-darwin";
+          break;
+        case "arm64":
+          targetTriple = "aarch64-apple-darwin";
+          break;
+        default:
+          break;
+      }
+      break;
+    case "win32":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-pc-windows-msvc.exe";
+          break;
+        case "arm64":
+        // We do not build this today, fall through...
+        default:
+          break;
+      }
+      break;
+    default:
+      break;
   }
-  try {
-    child.kill(signal);
-  } catch {
-    /* ignore */
+
+  if (!targetTriple) {
+    throw new Error(`Unsupported platform: ${platform} (${arch})`);
   }
-};
 
-["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
-  process.on(sig, () => forwardSignal(sig));
-});
+  const binaryPath = path.join(__dirname, "..", "bin", `codex-${targetTriple}`);
 
-// When the child exits, mirror its termination reason in the parent so that
-// shell scripts and other tooling observe the correct exit status.
-// Wrap the lifetime of the child process in a Promise so that we can await
-// its termination in a structured way. The Promise resolves with an object
-// describing how the child exited: either via exit code or due to a signal.
-const childResult = await new Promise((resolve) => {
-  child.on("exit", (code, signal) => {
-    if (signal) {
-      resolve({ type: "signal", signal });
-    } else {
-      resolve({ type: "code", exitCode: code ?? 1 });
-    }
+  // Use an asynchronous spawn instead of spawnSync so that Node is able to
+  // respond to signals (e.g. Ctrl-C / SIGINT) while the native binary is
+  // executing. This allows us to forward those signals to the child process
+  // and guarantees that when either the child terminates or the parent
+  // receives a fatal signal, both processes exit in a predictable manner.
+  const { spawn } = await import("child_process");
+
+  const additionalDirs = [];
+  const rgDir = await resolveRgDir();
+  if (rgDir) {
+    additionalDirs.push(rgDir);
+  }
+  const updatedPath = getUpdatedPath(additionalDirs);
+
+  const child = spawn(binaryPath, process.argv.slice(2), {
+    stdio: "inherit",
+    env: { ...process.env, PATH: updatedPath, CODEX_MANAGED_BY_NPM: "1" },
   });
-});
 
-if (childResult.type === "signal") {
-  // Re-emit the same signal so that the parent terminates with the expected
-  // semantics (this also sets the correct exit code of 128 + n).
-  process.kill(process.pid, childResult.signal);
-} else {
-  process.exit(childResult.exitCode);
+  child.on("error", (err) => {
+    // Typically triggered when the binary is missing or not executable.
+    // Re-throwing here will terminate the parent with a non-zero exit code
+    // while still printing a helpful stack trace.
+    // eslint-disable-next-line no-console
+    console.error(err);
+    process.exit(1);
+  });
+
+  // Forward common termination signals to the child so that it shuts down
+  // gracefully. In the handler we temporarily disable the default behavior of
+  // exiting immediately; once the child has been signaled we simply wait for
+  // its exit event which will in turn terminate the parent (see below).
+  const forwardSignal = (signal) => {
+    if (child.killed) {
+      return;
+    }
+    try {
+      child.kill(signal);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  ["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
+    process.on(sig, () => forwardSignal(sig));
+  });
+
+  // When the child exits, mirror its termination reason in the parent so that
+  // shell scripts and other tooling observe the correct exit status.
+  // Wrap the lifetime of the child process in a Promise so that we can await
+  // its termination in a structured way. The Promise resolves with an object
+  // describing how the child exited: either via exit code or due to a signal.
+  const childResult = await new Promise((resolve) => {
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        resolve({ type: "signal", signal });
+      } else {
+        resolve({ type: "code", exitCode: code ?? 1 });
+      }
+    });
+  });
+
+  if (childResult.type === "signal") {
+    // Re-emit the same signal so that the parent terminates with the expected
+    // semantics (this also sets the correct exit code of 128 + n).
+    process.kill(process.pid, childResult.signal);
+  } else {
+    process.exit(childResult.exitCode);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
 }

--- a/codex-cli/test/path.test.js
+++ b/codex-cli/test/path.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { getUpdatedPath } from "../bin/codex.js";
+
+test("getUpdatedPath avoids duplicate PATH entries on repeated invocation", () => {
+  const pathSep = process.platform === "win32" ? ";" : ":";
+  const originalPath = process.env.PATH;
+  const dir = path.join(process.cwd(), "dummy-dir");
+  try {
+    process.env.PATH = "";
+    const first = getUpdatedPath([dir]);
+    process.env.PATH = first;
+    const second = getUpdatedPath([dir]);
+    const occurrences = second.split(pathSep).filter((p) => p === dir).length;
+    assert.equal(occurrences, 1);
+  } finally {
+    process.env.PATH = originalPath;
+  }
+});


### PR DESCRIPTION
## Task
- **WHY:** CLI runs were appending duplicate PATH entries, bloating the environment.
- **OUTCOME:** `getUpdatedPath` now filters out directories already present; repeated executions leave `PATH` unchanged.
- **SURFACES TOUCHED:** `codex-cli/bin/codex.js`, `codex-cli/test/path.test.js`, `GOALS.md`, `DECISIONS.md`.
- **EXIT VIA SCENES:** `node --test`.
- **COMPATIBILITY:** no flags or migrations; behavior unchanged aside from deduplication.
- **NO-GO:** none identified.


------
https://chatgpt.com/codex/tasks/task_e_68a281b7b8a8832c9613558e73d04804