### PR TITLE
chore: canonicalize decisions log filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ CLAUDE.md
 
 # logs
 *.log
+!DECISIONS.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -18,6 +18,18 @@
 - **Links:** <PRs, scenes, interface entries, goal names>
 
 _(New entries go on top. Keep each under ~20 lines.)_
+### [2025-08-18] decisions-log-canonical
+
+- **Context:** Repository contained `DECISIONS.md` while documentation referenced `DECISIONS.log`, causing inconsistency.
+- **Decision:** Rename the decision log to `DECISIONS.log` and update references for a single canonical filename.
+- **Alternatives:** Keep `DECISIONS.md` and adjust all docs.
+- **Trade-offs:** `.log` extension receives less automatic Markdown tooling.
+- **Scope:** repository metadata files.
+- **Impact:** Eliminates confusion about where to record decisions.
+- **TTL / Review:** Revisit if extension hampers collaboration.
+- **Status:** ACTIVE
+- **Links:** this PR
+
 ### [2025-08-30] cli-exitcode-refactor
 
 - **Context:** Subcommands invoked std::process::exit directly, complicating error handling and testing.


### PR DESCRIPTION
## WHY
- eliminate confusion between `DECISIONS.md` and `DECISIONS.log`

## OUTCOME
- single canonical `DECISIONS.log` with recorded rationale
- ignore rules updated so the log stays searchable

## SURFACES TOUCHED
- `DECISIONS.log`
- `.gitignore`

## EXIT VIA SCENES
- `pnpm format` *(fails: code style issues in existing markdown files)*

## COMPATIBILITY
- documentation-only change

## NO-GO
- if tools require `.md` extension for the decision log

------
https://chatgpt.com/codex/tasks/task_e_68a2a11f430c832cbf67073d26fcc1ce